### PR TITLE
SI_Units.Metric.Scaling: workaroung GNAT FSF 8 hang

### DIFF
--- a/src/si_units-metric-scaling.ads
+++ b/src/si_units-metric-scaling.ads
@@ -19,9 +19,11 @@ package SI_Units.Metric.Scaling is
                      centi, deci,
                      None,
                      Deka, Hecto,
-                     kilo, Mega, Giga, Tera, Peta, Exa, Zetta, Yotta) with
-     Size => Integer'Size;
+                     kilo, Mega, Giga, Tera, Peta, Exa, Zetta, Yotta);
    pragma Warnings (On, "declaration hides ""Prefixes""");
+
+   for Prefixes'Size use Integer'Size;
+
    for Prefixes use (yocto => -24,
                      zepto => -21,
                      atto  => -18,


### PR DESCRIPTION
Compilation of the unit hangs with GNAT FSF 8.

Using `for Prefixes'Size use Integer'Size;` instead of `with Size =>` aspects fixes the problem.